### PR TITLE
4th agenda front

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ group :development, :test do
   gem "dotenv-rails"
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]
+  gem "hotwire-livereload"
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ group :development, :test do
   gem "dotenv-rails"
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]
-  gem "hotwire-livereload"
+  # gem "hotwire-livereload"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,6 +157,10 @@ GEM
       sassc (~> 2.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    hotwire-livereload (2.0.0)
+      actioncable (>= 7.0.0)
+      listen (>= 3.0.0)
+      railties (>= 7.0.0)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     importmap-rails (2.1.0)
@@ -172,6 +176,9 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.10.1)
+    listen (3.9.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.6.6)
     loofah (2.24.0)
       crass (~> 1.0.2)
@@ -268,6 +275,9 @@ GEM
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
     rake (13.2.1)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
     rdoc (6.12.0)
       psych (>= 4.0.0)
     regexp_parser (2.10.0)
@@ -349,6 +359,7 @@ DEPENDENCIES
   devise
   dotenv-rails
   font-awesome-sass (~> 6.1)
+  hotwire-livereload
   importmap-rails
   jbuilder
   pg (~> 1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,10 +157,6 @@ GEM
       sassc (~> 2.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    hotwire-livereload (2.0.0)
-      actioncable (>= 7.0.0)
-      listen (>= 3.0.0)
-      railties (>= 7.0.0)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     importmap-rails (2.1.0)
@@ -176,9 +172,6 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.10.1)
-    listen (3.9.0)
-      rb-fsevent (~> 0.10, >= 0.10.3)
-      rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.6.6)
     loofah (2.24.0)
       crass (~> 1.0.2)
@@ -275,9 +268,6 @@ GEM
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
     rake (13.2.1)
-    rb-fsevent (0.11.2)
-    rb-inotify (0.11.1)
-      ffi (~> 1.0)
     rdoc (6.12.0)
       psych (>= 4.0.0)
     regexp_parser (2.10.0)
@@ -359,7 +349,6 @@ DEPENDENCIES
   devise
   dotenv-rails
   font-awesome-sass (~> 6.1)
-  hotwire-livereload
   importmap-rails
   jbuilder
   pg (~> 1.1)

--- a/app/assets/stylesheets/components/_button_update_activity.scss
+++ b/app/assets/stylesheets/components/_button_update_activity.scss
@@ -1,0 +1,11 @@
+.btn-start {
+  background-color: $orange-autonome;
+  font-weight: bold;
+  border: 2px, solid, $dark-blue;
+}
+
+.btn-finish {
+  background-color: $orange-autonome;
+  font-weight: bold;
+  border: 1px, solid, $dark-blue;
+}

--- a/app/assets/stylesheets/components/_button_update_activity.scss
+++ b/app/assets/stylesheets/components/_button_update_activity.scss
@@ -8,6 +8,6 @@
   align-content: center;
 }
 
-.btn-details {
+.toggle-details {
   width: 65px;
 }

--- a/app/assets/stylesheets/components/_button_update_activity.scss
+++ b/app/assets/stylesheets/components/_button_update_activity.scss
@@ -7,3 +7,7 @@
   text-align: center;
   align-content: center;
 }
+
+.btn-details {
+  width: 65px;
+}

--- a/app/assets/stylesheets/components/_button_update_activity.scss
+++ b/app/assets/stylesheets/components/_button_update_activity.scss
@@ -1,11 +1,9 @@
-.btn-start {
+.btn-update {
   background-color: $orange-autonome;
   font-weight: bold;
-  border: 2px, solid, $dark-blue;
-}
-
-.btn-finish {
-  background-color: $orange-autonome;
-  font-weight: bold;
-  border: 1px, solid, $dark-blue;
+  border: 1px solid $dark-blue !important;
+  border-radius: 5px;
+  height: $time-height;
+  text-align: center;
+  align-content: center;
 }

--- a/app/assets/stylesheets/components/_card_agenda.scss
+++ b/app/assets/stylesheets/components/_card_agenda.scss
@@ -61,9 +61,35 @@
 /// Section of the card body (diplayed through Stimulus controller)
 
 .card-body{
-
+  display: flex;
+  justify-content:space-between;
+  align-items: start;
 }
 
+.left-side {
+  display: flex;
+  flex-direction: column;
+  width: fit-content;
+  justify-content: center;
+
+  img {
+    border-radius: 3px;
+    border: 1px solid $dark-blue;
+  }
+}
+
+.description {
+  flex-grow: 1;
+  padding-left: 10px;
+}
+
+.right-side {
+  display: flex;
+  flex-direction: column;
+  justify-content:space-between;
+  align-items: center;
+  gap: 12px
+}
 
 ///// end of card body /////
 

--- a/app/assets/stylesheets/components/_card_agenda.scss
+++ b/app/assets/stylesheets/components/_card_agenda.scss
@@ -1,23 +1,26 @@
 .margin-from-navbar {
   height: 65px;
 }
-
-.list-activities {
-  position: relative;
+//  class of the div for JS controller
+.a-dallas {
+  margin-left: 15px;
+  margin-right: 15px;
 }
 
 .card-agenda {
-  background-color: #073b4c;
+  position: relative;
   min-height: fit-content;
   padding: 1px;
   border-radius: 5px;
   width: 100%;
+  border: 1px solid $dark-blue;
+  display: flex;
 }
 
 .starting-time {
   position: absolute;
-  top: 0px;
-  left: 0px;
+  top: -1px;
+  left: -1px;
   background-color: white;
   height: $time-height;
   width: 65px;
@@ -28,20 +31,17 @@
   vertical-align: middle;
   font-size: large;
   font-weight: bold;
-  border: 1px, solid, $dark-blue;
+  border: 1px solid $dark-blue;
 }
 
-.card-body {
-  padding-top: 5px;
-  height: 100px;
-  text-align: center;
-  justify-content: center;
-  font-size: x-large;
+.activity-name {
   font-weight: 600;
-  border-radius: 5px;
-  width: 100%;
+  padding-top: 5px;
+  font-size: x-large;
 }
 
+// class to set the background color
+// according to type of activity
 .journey {
   background-color: $yellow-autonome;
 }
@@ -61,9 +61,4 @@
   width: calc(100% - 30px);
   left: 15px;
   right: 15px;
-}
-
-.a-dallas {
-  margin-left: 15px;
-  margin-right: 15px;
 }

--- a/app/assets/stylesheets/components/_card_agenda.scss
+++ b/app/assets/stylesheets/components/_card_agenda.scss
@@ -1,5 +1,5 @@
 .margin-from-navbar {
-  height: 60px;
+  height: 65px;
 }
 
 .list-activities {
@@ -9,8 +9,6 @@
 .card-agenda {
   background-color: #073b4c;
   min-height: fit-content;
-  margin-left: 15px;
-  margin-right: 15px;
   padding: 1px;
   border-radius: 5px;
   width: 100%;
@@ -56,15 +54,16 @@
   background-color: $breaktime;
 }
 
-.loading {
-  background-color: $orange-autonome;
-  border-radius: 5px;
-  width: 20px;
-  height: fit-content;
-}
-
 .in-progress {
   position: fixed;
-  top:60px;
+  top:65px;
   z-index: 10;
+  width: calc(100% - 30px);
+  left: 15px;
+  right: 15px;
+}
+
+.a-dallas {
+  margin-left: 15px;
+  margin-right: 15px;
 }

--- a/app/assets/stylesheets/components/_card_agenda.scss
+++ b/app/assets/stylesheets/components/_card_agenda.scss
@@ -14,7 +14,19 @@
   border-radius: 5px;
   width: 100%;
   border: 1px solid $dark-blue;
-  display: flex;
+  display: block;
+}
+
+/// Section of the card head (always visible)
+
+.card-header {
+  margin-left: 65px; //offset to ovoid starting time overlay (fixed)
+  padding-top: 5px;
+  padding-bottom: 5px;
+  display: flex; // Utilise flex pour aligner horizontalement le nom et le bouton
+  justify-content: space-between; // Espace entre le nom et le bouton
+  align-items: center;
+  width: calc(100% - 65px);
 }
 
 .starting-time {
@@ -32,16 +44,32 @@
   font-size: large;
   font-weight: bold;
   border: 1px solid $dark-blue;
+  z-index: 1; // Assure qu'il est au-dessus des autres éléments
 }
 
 .activity-name {
+  // padding-left: 15px;
   font-weight: 600;
-  padding-top: 5px;
   font-size: x-large;
+  text-align: center;
+  // text-align: left;
+  flex-grow: 1;
 }
 
-// class to set the background color
-// according to type of activity
+/////// end of card head /////
+
+/// Section of the card body (diplayed through Stimulus controller)
+
+.card-body{
+
+}
+
+
+///// end of card body /////
+
+
+/// class to set the background color
+/// according to type of activity
 .journey {
   background-color: $yellow-autonome;
 }

--- a/app/assets/stylesheets/components/_card_agenda.scss
+++ b/app/assets/stylesheets/components/_card_agenda.scss
@@ -1,3 +1,11 @@
+.margin-from-navbar {
+  height: 60px;
+}
+
+.list-activities {
+  position: relative;
+}
+
 .card-agenda {
   background-color: #073b4c;
   min-height: fit-content;
@@ -5,6 +13,7 @@
   margin-right: 15px;
   padding: 1px;
   border-radius: 5px;
+  width: 100%;
 }
 
 .starting-time {
@@ -32,6 +41,7 @@
   font-size: x-large;
   font-weight: 600;
   border-radius: 5px;
+  width: 100%;
 }
 
 .journey {
@@ -57,9 +67,4 @@
   position: fixed;
   top:60px;
   z-index: 10;
-  width: 100%;
-}
-
-.list-activities {
-  position: relative;
 }

--- a/app/assets/stylesheets/components/_card_agenda.scss
+++ b/app/assets/stylesheets/components/_card_agenda.scss
@@ -56,6 +56,11 @@
   flex-grow: 1;
 }
 
+.fa-caret-rotated {
+  transform: rotate(180deg);
+  transition: transform 0.3s ease;
+}
+
 /////// end of card head /////
 
 /// Section of the card body (diplayed through Stimulus controller)

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -4,4 +4,5 @@
 @import "form_legend_clear";
 @import "navbar";
 @import "card_agenda";
-@import "help_calls"
+@import "help_calls";
+@import "button_update_activity"

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -11,12 +11,24 @@ class ActivitiesController < ApplicationController
   end
 
   def start
+    # Rails.logger.info "Params reçus : #{params.inspect}" # pour debugg
     @activity = Activity.find(params[:activity_id])
 
     if @activity.update(activity_status: "inprogress")
-      render json: { update_message: "L'activité est démarrée" }
+      render json: { update_message: "L'activité est démarrée", status: true }
     else
-      render json: { update_message: "Erreur, l'activité n'est pas démarrée" }, status: :unprocessable_entity
+      render json: { update_message: "Erreur, l'activité n'est pas démarrée", status: false }, status: :unprocessable_entity
     end
   end
+
+  def finish
+    @activity = Activity.find(params[:activity_id])
+
+    if @activity.update(activity_status: "finished")
+      render json: { update_message: "L'activité est terminée", status: true }
+    else
+      render json: { update_message: "Erreur, l'activité n'est pas terminée", status: false }, status: :unprocessable_entity
+    end
+  end
+
 end

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -2,10 +2,21 @@ class ActivitiesController < ApplicationController
 
   def mes_activites
     @activities = Activity.all.order(starting_date: "asc")
-    @active_activity = @activities.first
+    @current_activity = @activities.find_by(activity_status: "inprogress")
+    @next_activity = @activities.find_by(activity_status: "planned")
   end
 
   def show
     @activity = Activity.find(params[:id])
+  end
+
+  def start
+    @activity = Activity.find(params[:activity_id])
+
+    if @activity.update(activity_status: "inprogress")
+      render json: { update_message: "L'activité est démarrée" }
+    else
+      render json: { update_message: "Erreur, l'activité n'est pas démarrée" }, status: :unprocessable_entity
+    end
   end
 end

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -30,5 +30,4 @@ class ActivitiesController < ApplicationController
       render json: { update_message: "Erreur, l'activité n'est pas terminée", status: false }, status: :unprocessable_entity
     end
   end
-
 end

--- a/app/javascript/controllers/toggle_details_controller.js
+++ b/app/javascript/controllers/toggle_details_controller.js
@@ -3,7 +3,7 @@ import { Controller } from "@hotwired/stimulus"
 // Connects to data-controller="toggle-details"
 export default class extends Controller {
 
-  static targets = ["togglableElement"]
+  static targets = ["togglableElement", "caretIcon"]
   static values = { activityId: Number }
   connect() {
     console.log("Toggle details connected");
@@ -13,6 +13,7 @@ export default class extends Controller {
     event.preventDefault();
     console.log(this.togglableElementTarget)
     this.togglableElementTarget.classList.toggle("d-none");
+    this.caretIconTarget.classList.toggle("fa-caret-rotated");
     console.log("Activity-ID:", event.params.activityId);
   }
 }

--- a/app/javascript/controllers/toggle_details_controller.js
+++ b/app/javascript/controllers/toggle_details_controller.js
@@ -4,7 +4,6 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
 
   static targets = ["togglableElement"]
-  // static values = { activity: Object } // Permet de stocker et accéder à l'instance activity
   static values = { activityId: Number }
   connect() {
     console.log("Toggle details connected");
@@ -12,7 +11,8 @@ export default class extends Controller {
 
   display(event) {
     event.preventDefault();
+    console.log(this.togglableElementTarget)
     this.togglableElementTarget.classList.toggle("d-none");
-    console.log("Activity-ID:", this.activityIdValue);
+    console.log("Activity-ID:", event.params.activityId);
   }
 }

--- a/app/javascript/controllers/toggle_details_controller.js
+++ b/app/javascript/controllers/toggle_details_controller.js
@@ -1,0 +1,17 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="toggle-details"
+export default class extends Controller {
+
+  static targets = ["togglableElement"]
+  static values = { activity: Object } // Permet de stocker et accéder à l'instance activity
+
+  connect() {
+    console.log("Toggle details connected");
+  }
+
+  display() {
+    this.togglableElementTarget.classList.toggle("d-none");
+    console.log(this.activityValue) // Pour vérifier qu'on récupère bien l'instance activity
+  }
+}

--- a/app/javascript/controllers/toggle_details_controller.js
+++ b/app/javascript/controllers/toggle_details_controller.js
@@ -4,14 +4,15 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
 
   static targets = ["togglableElement"]
-  static values = { activity: Object } // Permet de stocker et accéder à l'instance activity
-
+  // static values = { activity: Object } // Permet de stocker et accéder à l'instance activity
+  static values = { activityId: Number }
   connect() {
     console.log("Toggle details connected");
   }
 
-  display() {
+  display(event) {
+    event.preventDefault();
     this.togglableElementTarget.classList.toggle("d-none");
-    console.log(this.activityValue) // Pour vérifier qu'on récupère bien l'instance activity
+    console.log("Activity-ID:", this.activityIdValue);
   }
 }

--- a/app/javascript/controllers/update_activity_button_controller.js
+++ b/app/javascript/controllers/update_activity_button_controller.js
@@ -1,0 +1,37 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+
+  static targets = ["start-button"]
+
+  connect() {
+    console.log("I'm connected");
+  }
+
+  start(event) {
+    event.preventDefault();
+    console.log(event.target.getAttribute("data-activity-id"))
+    const activityId = event.target.getAttribute("data-activity-id");
+
+    // fetch("/activites", {
+    //   method: 'PATCH',
+    //   headers: {
+    //     "Content-Type": "application/json",
+    //   },
+    //   body: JSON.stringify({
+    //     activity_id: activityId,  // ID de l'activité à mettre à jour
+    //     activity_status: 'inprogress'  // Nouveau statut (par exemple, 'inprogress')
+    //   })
+    // })
+
+    // .then(response => response.json())
+    // .then(data => {
+    //   // ajouter un rafraichissement de la page pour que la carte inprogress
+    //   // s'affiche et soit collée à la navbar
+    //   console.log(data);
+    // })
+    // .catch(error => {
+    //   console.error("Erreur:", error);
+    // });
+  }
+}

--- a/app/javascript/controllers/update_activity_button_controller.js
+++ b/app/javascript/controllers/update_activity_button_controller.js
@@ -9,29 +9,59 @@ export default class extends Controller {
   }
 
   start(event) {
-    event.preventDefault();
+    // event.preventDefault(); désactivé car il faut recharger la page pour afficher l'activité en cours
     console.log(event.target.getAttribute("data-activity-id"))
     const activityId = event.target.getAttribute("data-activity-id");
 
-    // fetch("/activites", {
-    //   method: 'PATCH',
-    //   headers: {
-    //     "Content-Type": "application/json",
-    //   },
-    //   body: JSON.stringify({
-    //     activity_id: activityId,  // ID de l'activité à mettre à jour
-    //     activity_status: 'inprogress'  // Nouveau statut (par exemple, 'inprogress')
-    //   })
-    // })
+    fetch(`/activities/${activityId}/start`, {
+      method: 'PATCH',
+      headers: {
+        "Content-Type": "application/json",
+        "Accept": "application/json", //important, sinon le format json n'est pas reconnu
+        "X-CSRF-Token": document.querySelector('meta[name="csrf-token"]').content
+      },
+      body: JSON.stringify({
+        // activity_id: activityId,  // ID de l'activité à mettre à jour
+        // activity_status: 'inprogress'  // Nouveau statut (par exemple, 'inprogress')
+      })
+    })
 
-    // .then(response => response.json())
-    // .then(data => {
-    //   // ajouter un rafraichissement de la page pour que la carte inprogress
-    //   // s'affiche et soit collée à la navbar
-    //   console.log(data);
-    // })
-    // .catch(error => {
-    //   console.error("Erreur:", error);
-    // });
+    // proposition de Claude pour la gestion des erreurs
+    .then(response => {
+      console.log("Response status:", response.status);
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+      return response.json();
+    })
+    .then(data => {
+      console.log("Success:", data);
+      window.location.reload();
+    })
+    .catch(error => {
+      console.error("Erreur complète:", error);
+    });
+  }
+
+  finish(event) {
+    console.log(event.target.getAttribute("data-activity-id"))
+    const activityId = event.target.getAttribute("data-activity-id");
+    
+    fetch(`/activities/${activityId}/finish`, {
+      method: 'PATCH',
+      headers: {
+        "Content-Type": "application/json",
+        "Accept": "application/json", //important, sinon le format json n'est pas reconnu
+        "X-CSRF-Token": document.querySelector('meta[name="csrf-token"]').content
+      },
+      body: JSON.stringify({})
+    })
+    .then(data => {
+      console.log("Success:", data);
+      window.location.reload();
+    })
+    .catch(error => {
+      console.error("Erreur complète:", error);
+    });
   }
 }

--- a/app/javascript/controllers/update_activity_button_controller.js
+++ b/app/javascript/controllers/update_activity_button_controller.js
@@ -10,7 +10,7 @@ export default class extends Controller {
 
   start(event) {
     // event.preventDefault(); désactivé car il faut recharger la page pour afficher l'activité en cours
-    console.log(event.target.getAttribute("data-activity-id"))
+    // console.log(event.target.getAttribute("data-activity-id"))
     const activityId = event.target.getAttribute("data-activity-id");
 
     fetch(`/activities/${activityId}/start`, {
@@ -44,9 +44,9 @@ export default class extends Controller {
   }
 
   finish(event) {
-    console.log(event.target.getAttribute("data-activity-id"))
+    // console.log(event.target.getAttribute("data-activity-id"))
     const activityId = event.target.getAttribute("data-activity-id");
-    
+
     fetch(`/activities/${activityId}/finish`, {
       method: 'PATCH',
       headers: {

--- a/app/views/activities/_activity_details.html.erb
+++ b/app/views/activities/_activity_details.html.erb
@@ -8,6 +8,13 @@
 </div>
 <div class="right-side">
   <%=cl_image_tag(activity.educator.user.photo.key, crop: :fill, class: "avatar-large" )%>
+  <% if activity == @next_activity && @current_activity.nil? %>
+    <button class="btn btn-update btn-sm"
+      data-action="click->update-activity-button#start"
+      data-activity-id="<%= activity.id %>">
+      Start !
+    </button>
+    <% end %>
   <% if activity.activity_status == "inprogress" %>
     <button class="btn btn-update btn-sm"
       data-action="click->update-activity-button#finish"

--- a/app/views/activities/_activity_details.html.erb
+++ b/app/views/activities/_activity_details.html.erb
@@ -1,0 +1,18 @@
+<div class="left-side">
+  <%=cl_image_tag(activity.photo.key,width: 80, height: 60, crop: :fill)%>
+  <p>Checklist</p>
+</div>
+<div class="description">
+  <p><%= activity.description  %>
+  <%= activity.activity_status  %></p>
+</div>
+<div class="right-side">
+  <%=cl_image_tag(activity.educator.user.photo.key, crop: :fill, class: "avatar-large" )%>
+  <% if activity.activity_status == "inprogress" %>
+    <button class="btn btn-update btn-sm"
+      data-action="click->update-activity-button#finish"
+      data-activity-id="<%= activity.id %>">
+      Done !
+    </button>
+  <% end %>
+</div>

--- a/app/views/activities/_current_activity.html.erb
+++ b/app/views/activities/_current_activity.html.erb
@@ -1,4 +1,4 @@
-<div class="card-body <%=activity.activity_type%>"
+<div class="card-header <%=activity.activity_type%>"
               style="height:  <%= (activity.ending_date - activity.starting_date)/40%>px">
           <%= activity.name %>
         </div>

--- a/app/views/activities/mes_activites.html.erb
+++ b/app/views/activities/mes_activites.html.erb
@@ -2,38 +2,35 @@
 <div class="a-dallas" data-controller="update-activity-button">
   <%# first card is fixed, it is the activity in progress if there is any%>
   <% if @current_activity %>
-    <div class = "card-agenda in-progress">
-      <div class="card-body <%=@current_activity.activity_type%>"
+      <div class="card-agenda in-progress <%=@current_activity.activity_type%>"
           style="height:  <%= (@current_activity.ending_date - @current_activity.starting_date)/40%>px">
-          <%= @current_activity.name %>
-          <button class="btn btn-finish"
+          <div class = "starting-time"></div> <%# space kept for loading bar %>
+          <div class= "activity-name"><%= @current_activity.name %></div>
+          <button class="btn btn-update btn-sm"
                       data-action="click->update-activity-button#finish"
                       data-activity-id="<%= @current_activity.id %>">
                       J'ai terminé
               </button>
       </div>
-    </div>
   <% end %>
   <%# displays all the cards of activities  %>
   <%# note that the first one is the activity in progress, displayed behind the previous one fixed %>
     <% @activities.each do |activity| %>
       <% if activity.activity_status != "finished" %>
-        <div class = "card-agenda list-activities">
-          <div class = "starting-time">
-              <p><%= activity.starting_date.strftime("%H:%M")  %></p>
-          </div>
-          <div class="card-body <%=activity.activity_type%>"
+          <div class="card-agenda <%=activity.activity_type%>"
                 style="height:  <%= (activity.ending_date - activity.starting_date)/40%>px">
-            <div class= ""><%= activity.name %></div>
+            <div class = "starting-time">
+                <p><%= activity.starting_date.strftime("%H:%M")  %></p>
+            </div>
+            <div class= "activity-name"><%= activity.name %></div>
             <% if activity == @next_activity && @current_activity.nil? %>
-              <button class="btn btn-start"
+              <button class="btn btn-update btn-sm"
                       data-action="click->update-activity-button#start"
                       data-activity-id="<%= activity.id %>">
                       Je commence
               </button>
               <% end %>
           </div>
-        </div>
       <% end %>
     <% end %>
   </div>

--- a/app/views/activities/mes_activites.html.erb
+++ b/app/views/activities/mes_activites.html.erb
@@ -7,11 +7,11 @@
           <div class = "starting-time"></div> <%# space kept for loading bar, no time value displayed %>
           <div class="card-header">
             <div class= "activity-name"><%= @current_activity.name %></div>
-            <button class="btn btn-update btn-sm"
-                      data-action="click->update-activity-button#finish"
-                      data-activity-id="<%= @current_activity.id %>">
-                      Done !
-            </button>
+              <button data-action="click->toggle-details#display"
+                      data-toggle-details-activity-id-value="<%= @current_activity.id %>"
+                      class="btn toggle-details">
+                <i class="fa-solid fa-caret-down"></i>
+              </button>
           </div>
       </div>
   <% end %>
@@ -26,7 +26,9 @@
             </div>
             <div class="card-header">
               <div class= "activity-name"><%= activity.name %></div>
-              <button data-action="click->toggle-details#display" class="btn toggle-details">
+              <button data-action="click->toggle-details#display"
+                      data-toggle-details-activity-id-value="<%= activity.id %>"
+                      class="btn toggle-details">
                 <i class="fa-solid fa-caret-down"></i>
               </button>
               <% if activity == @next_activity && @current_activity.nil? %>
@@ -39,7 +41,6 @@
             </div>
             <%# the rest of the information of the activity is displayed on demand %>
             <div data-toggle-details-target="togglableElement"
-                data-toggle-details-activity-value="<%= activity.to_json %>"
                 class="card-body d-none">
               <%= render "activity_details", activity: activity  %>
             </div>

--- a/app/views/activities/mes_activites.html.erb
+++ b/app/views/activities/mes_activites.html.erb
@@ -11,7 +11,7 @@
               <button data-action="click->toggle-details#display"
                       data-toggle-details-activity-id-param="<%= @current_activity.id %>"
                       class="btn toggle-details">
-                <i class="fa-solid fa-caret-down"></i>
+                <i class="fa-solid fa-caret-down" data-toggle-details-target="caretIcon"></i>
               </button>
           </div>
           <%# the rest of the information of the activity is displayed on demand %>
@@ -36,7 +36,7 @@
             <button data-action="click->toggle-details#display"
                     data-toggle-details-activity-id-param="<%= activity.id %>"
                     class="btn toggle-details">
-              <i class="fa-solid fa-caret-down"></i>
+              <i class="fa-solid fa-caret-down" data-toggle-details-target="caretIcon"></i>
             </button>
           </div>
           <%# the rest of the information of the activity is displayed on demand %>

--- a/app/views/activities/mes_activites.html.erb
+++ b/app/views/activities/mes_activites.html.erb
@@ -6,6 +6,12 @@
       <div class="card-body <%=@current_activity.activity_type%>"
           style="height:  <%= (@current_activity.ending_date - @current_activity.starting_date)/40%>px">
           <%= @current_activity.name %>
+          <%= @current_activity.activity_status %>
+          <button class="btn btn-primary btn-lg"
+                      data-action="click->update-activity-button#finish"
+                      data-activity-id="<%= @current_activity.id %>">
+                      Finish this activity
+              </button>
       </div>
     </div>
   <% end %>
@@ -19,6 +25,7 @@
           <div class="card-body <%=activity.activity_type%>"
                 style="height:  <%= (activity.ending_date - activity.starting_date)/40%>px">
             <%= activity.name %>
+            <%= activity.activity_status %>
             <% if activity == @next_activity && @current_activity.nil? %>
               <button class="btn btn-primary btn-lg"
                       data-action="click->update-activity-button#start"

--- a/app/views/activities/mes_activites.html.erb
+++ b/app/views/activities/mes_activites.html.erb
@@ -1,51 +1,51 @@
 <div class="margin-from-navbar"></div>
-<div class="a-dallas" data-controller="update-activity-button toggle-details">
+<div class="a-dallas" data-controller="update-activity-button">
   <%# first card is fixed, it is the activity in progress if there is any%>
   <% if @current_activity %>
       <div class="card-agenda in-progress <%=@current_activity.activity_type%>"
+          data-controller="toggle-details"
           style="height:  <%= (@current_activity.ending_date - @current_activity.starting_date)/40%>px">
           <div class = "starting-time"></div> <%# space kept for loading bar, no time value displayed %>
           <div class="card-header">
             <div class= "activity-name"><%= @current_activity.name %></div>
               <button data-action="click->toggle-details#display"
-                      data-toggle-details-activity-id-value="<%= @current_activity.id %>"
+                      data-toggle-details-activity-id-param="<%= @current_activity.id %>"
                       class="btn toggle-details">
                 <i class="fa-solid fa-caret-down"></i>
               </button>
           </div>
+          <%# the rest of the information of the activity is displayed on demand %>
+            <div data-toggle-details-target="togglableElement"
+                class="card-body d-none">
+              <%= render "activity_details", activity: @current_activity  %>
+            </div>
       </div>
   <% end %>
   <%# displays all the cards of activities  %>
   <%# note that the first one is the activity in progress, displayed behind the previous one fixed %>
-    <% @activities.each do |activity| %>
-      <% if activity.activity_status != "finished" %>
-          <div class="card-agenda <%=activity.activity_type%>"
-                style="height:  <%= (activity.ending_date - activity.starting_date)/40%>px">
-            <div class = "starting-time">
-                <p><%= activity.starting_date.strftime("%H:%M")  %></p>
-            </div>
-            <div class="card-header">
-              <div class= "activity-name"><%= activity.name %></div>
-              <button data-action="click->toggle-details#display"
-                      data-toggle-details-activity-id-value="<%= activity.id %>"
-                      class="btn toggle-details">
-                <i class="fa-solid fa-caret-down"></i>
-              </button>
-              <% if activity == @next_activity && @current_activity.nil? %>
-                <button class="btn btn-update btn-sm"
-                        data-action="click->update-activity-button#start"
-                        data-activity-id="<%= activity.id %>">
-                        Start !
-                </button>
-              <% end %>
-            </div>
-            <%# the rest of the information of the activity is displayed on demand %>
-            <div data-toggle-details-target="togglableElement"
-                class="card-body d-none">
-              <%= render "activity_details", activity: activity  %>
-            </div>
+  <% @activities.each do |activity| %>
+    <% if activity.activity_status != "finished" %>
+        <div class="card-agenda <%=activity.activity_type%>"
+            data-controller="toggle-details"
+              style="height:  <%= (activity.ending_date - activity.starting_date)/40%>px">
+          <div class = "starting-time">
+              <p><%= activity.starting_date.strftime("%H:%M")  %></p>
           </div>
-      <% end %> <%# close the condition if status not finished  %>
-    <% end %> <%# Close the each loop %>
+          <div class="card-header">
+            <div class= "activity-name"><%= activity.name %></div>
+            <button data-action="click->toggle-details#display"
+                    data-toggle-details-activity-id-param="<%= activity.id %>"
+                    class="btn toggle-details">
+              <i class="fa-solid fa-caret-down"></i>
+            </button>
+          </div>
+          <%# the rest of the information of the activity is displayed on demand %>
+          <div data-toggle-details-target="togglableElement"
+              class="card-body d-none">
+            <%= render "activity_details", activity: activity  %>
+          </div>
+        </div>
+    <% end %> <%# close the condition if status not finished  %>
+  <% end %> <%# Close the each loop %>
   </div>
 </div>

--- a/app/views/activities/mes_activites.html.erb
+++ b/app/views/activities/mes_activites.html.erb
@@ -1,25 +1,33 @@
 <div class="margin-from-navbar"></div>
-<div class = "card-agenda in-progress">
-  <div class="card-body <%=@active_activity.activity_type%>"
-      style="height:  <%= (@active_activity.ending_date - @active_activity.starting_date)/40%>px">
-      <%= @active_activity.name %>
-  </div>
-</div>
-  <% @activities.each_with_index do |activity, index| %>
-      <div class = "card-agenda list-activities">
-        <div class = "starting-time">
-            <p><%= activity.starting_date.strftime("%H:%M")  %></p>
-        </div>
-        <div class="card-body <%=activity.activity_type%>"
-              style="height:  <%= (activity.ending_date - activity.starting_date)/40%>px">
-          <%= activity.name %>
-        </div>
+<div data-controller="update-activity-button">
+  <%# first card is fixed, it is the activity in progress if there is any%>
+  <% if @current_activity %>
+    <div class = "card-agenda in-progress">
+      <div class="card-body <%=@current_activity.activity_type%>"
+          style="height:  <%= (@current_activity.ending_date - @current_activity.starting_date)/40%>px">
+          <%= @current_activity.name %>
       </div>
-      <div class = "card-agenda in-progress">
-        <div class="card-body <%=@active_activity.activity_type%>"
-            style="height:  <%= (@active_activity.ending_date - @active_activity.starting_date)/40%>px">
-            <%= @active_activity.name %>
-        </div>
-      </div>
+    </div>
   <% end %>
+  <%# displays all the cards of activities  %>
+  <%# note that the first one is the activity in progress, displayed behind the previous one fixed %>
+    <% @activities.each do |activity| %>
+        <div class = "card-agenda list-activities">
+          <div class = "starting-time">
+              <p><%= activity.starting_date.strftime("%H:%M")  %></p>
+          </div>
+          <div class="card-body <%=activity.activity_type%>"
+                style="height:  <%= (activity.ending_date - activity.starting_date)/40%>px">
+            <%= activity.name %>
+            <% if activity == @next_activity && @current_activity.nil? %>
+              <button class="btn btn-primary btn-lg"
+                      data-action="click->update-activity-button#start"
+                      data-activity-id="<%= activity.id %>">
+                      Start this activity
+              </button>
+              <% end %>
+          </div>
+        </div>
+    <% end %>
+  </div>
 </div>

--- a/app/views/activities/mes_activites.html.erb
+++ b/app/views/activities/mes_activites.html.erb
@@ -18,6 +18,7 @@
   <%# displays all the cards of activities  %>
   <%# note that the first one is the activity in progress, displayed behind the previous one fixed %>
     <% @activities.each do |activity| %>
+      <% if activity.activity_status != "finished" %>
         <div class = "card-agenda list-activities">
           <div class = "starting-time">
               <p><%= activity.starting_date.strftime("%H:%M")  %></p>
@@ -35,6 +36,7 @@
               <% end %>
           </div>
         </div>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/activities/mes_activites.html.erb
+++ b/app/views/activities/mes_activites.html.erb
@@ -4,13 +4,15 @@
   <% if @current_activity %>
       <div class="card-agenda in-progress <%=@current_activity.activity_type%>"
           style="height:  <%= (@current_activity.ending_date - @current_activity.starting_date)/40%>px">
-          <div class = "starting-time"></div> <%# space kept for loading bar %>
-          <div class= "activity-name"><%= @current_activity.name %></div>
-          <button class="btn btn-update btn-sm"
+          <div class = "starting-time"></div> <%# space kept for loading bar, no time value displayed %>
+          <div class="card-header">
+            <div class= "activity-name"><%= @current_activity.name %></div>
+            <button class="btn btn-update btn-sm"
                       data-action="click->update-activity-button#finish"
                       data-activity-id="<%= @current_activity.id %>">
-                      J'ai terminé
-              </button>
+                      Done !
+            </button>
+          </div>
       </div>
   <% end %>
   <%# displays all the cards of activities  %>
@@ -22,16 +24,21 @@
             <div class = "starting-time">
                 <p><%= activity.starting_date.strftime("%H:%M")  %></p>
             </div>
-            <div class= "activity-name"><%= activity.name %></div>
-            <% if activity == @next_activity && @current_activity.nil? %>
-              <button class="btn btn-update btn-sm"
-                      data-action="click->update-activity-button#start"
-                      data-activity-id="<%= activity.id %>">
-                      Je commence
-              </button>
+            <div class="card-header">
+              <div class= "activity-name"><%= activity.name %></div>
+              <button class="btn btn-details"><i class="fa-solid fa-caret-down"></i></button>
+              <% if activity == @next_activity && @current_activity.nil? %>
+                <button class="btn btn-update btn-sm"
+                        data-action="click->update-activity-button#start"
+                        data-activity-id="<%= activity.id %>">
+                        Start !
+                </button>
               <% end %>
+            </div>
+            <div class="card-body">
+            </div>
           </div>
-      <% end %>
-    <% end %>
+      <% end %> <%# close the condition if status not finished  %>
+    <% end %> <%# Close the each loop %>
   </div>
 </div>

--- a/app/views/activities/mes_activites.html.erb
+++ b/app/views/activities/mes_activites.html.erb
@@ -1,5 +1,5 @@
 <div class="margin-from-navbar"></div>
-<div class="a-dallas" data-controller="update-activity-button">
+<div class="a-dallas" data-controller="update-activity-button toggle-details">
   <%# first card is fixed, it is the activity in progress if there is any%>
   <% if @current_activity %>
       <div class="card-agenda in-progress <%=@current_activity.activity_type%>"
@@ -26,7 +26,9 @@
             </div>
             <div class="card-header">
               <div class= "activity-name"><%= activity.name %></div>
-              <button class="btn btn-details"><i class="fa-solid fa-caret-down"></i></button>
+              <button data-action="click->toggle-details#display" class="btn toggle-details">
+                <i class="fa-solid fa-caret-down"></i>
+              </button>
               <% if activity == @next_activity && @current_activity.nil? %>
                 <button class="btn btn-update btn-sm"
                         data-action="click->update-activity-button#start"
@@ -35,7 +37,11 @@
                 </button>
               <% end %>
             </div>
-            <div class="card-body">
+            <%# the rest of the information of the activity is displayed on demand %>
+            <div data-toggle-details-target="togglableElement"
+                data-toggle-details-activity-value="<%= activity.to_json %>"
+                class="card-body d-none">
+              <%= render "activity_details", activity: activity  %>
             </div>
           </div>
       <% end %> <%# close the condition if status not finished  %>

--- a/app/views/activities/mes_activites.html.erb
+++ b/app/views/activities/mes_activites.html.erb
@@ -1,16 +1,15 @@
 <div class="margin-from-navbar"></div>
-<div data-controller="update-activity-button">
+<div class="a-dallas" data-controller="update-activity-button">
   <%# first card is fixed, it is the activity in progress if there is any%>
   <% if @current_activity %>
     <div class = "card-agenda in-progress">
       <div class="card-body <%=@current_activity.activity_type%>"
           style="height:  <%= (@current_activity.ending_date - @current_activity.starting_date)/40%>px">
           <%= @current_activity.name %>
-          <%= @current_activity.activity_status %>
-          <button class="btn btn-primary btn-lg"
+          <button class="btn btn-finish"
                       data-action="click->update-activity-button#finish"
                       data-activity-id="<%= @current_activity.id %>">
-                      Finish this activity
+                      J'ai terminé
               </button>
       </div>
     </div>
@@ -25,13 +24,12 @@
           </div>
           <div class="card-body <%=activity.activity_type%>"
                 style="height:  <%= (activity.ending_date - activity.starting_date)/40%>px">
-            <%= activity.name %>
-            <%= activity.activity_status %>
+            <div class= ""><%= activity.name %></div>
             <% if activity == @next_activity && @current_activity.nil? %>
-              <button class="btn btn-primary btn-lg"
+              <button class="btn btn-start"
                       data-action="click->update-activity-button#start"
                       data-activity-id="<%= activity.id %>">
-                      Start this activity
+                      Je commence
               </button>
               <% end %>
           </div>

--- a/app/views/activities/mes_activites.html.erb
+++ b/app/views/activities/mes_activites.html.erb
@@ -1,15 +1,11 @@
-<h1>Mes Activités</h1>
+<div class="margin-from-navbar"></div>
 <div class = "card-agenda in-progress">
   <div class="card-body <%=@active_activity.activity_type%>"
       style="height:  <%= (@active_activity.ending_date - @active_activity.starting_date)/40%>px">
       <%= @active_activity.name %>
   </div>
 </div>
-<%# décalage manuel très moche, pas moyen de blocquer la 1ère activité %>
-<div class="d-flex flex-column mt-5" style= "margin-top:25px">
-  </div>
   <% @activities.each_with_index do |activity, index| %>
-    <% if index >0 %>
       <div class = "card-agenda list-activities">
         <div class = "starting-time">
             <p><%= activity.starting_date.strftime("%H:%M")  %></p>
@@ -19,6 +15,11 @@
           <%= activity.name %>
         </div>
       </div>
-    <% end %>
+      <div class = "card-agenda in-progress">
+        <div class="card-body <%=@active_activity.activity_type%>"
+            style="height:  <%= (@active_activity.ending_date - @active_activity.starting_date)/40%>px">
+            <%= @active_activity.name %>
+        </div>
+      </div>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,4 +13,6 @@ Rails.application.routes.draw do
   get 'myprofil', to: 'users#show', as: "myprofil"
   get 'myprofil' => 'users#show', as: :myprofil_root # creates user_root_path after log in
   get 'help_needed', to: 'helpcalls#index'
+  # route for stimulus controller (start/e)
+  patch 'activites/:id/update_status', to: 'activites#start', as: 'update_activity_status'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
   get 'myprofil', to: 'users#show', as: "myprofil"
   get 'myprofil' => 'users#show', as: :myprofil_root # creates user_root_path after log in
   get 'help_needed', to: 'helpcalls#index'
-  # route for stimulus controller (start/e)
-  patch 'activites/:id/update_status', to: 'activites#start', as: 'update_activity_status'
+  # routes for stimulus controller (start/finish)
+  patch 'activities/:activity_id/start', to: 'activities#start'
+  patch 'activities/:activity_id/finish', to: 'activities#finish'
 end

--- a/db/migrate/20250315100458_add_status_to_activities.rb
+++ b/db/migrate/20250315100458_add_status_to_activities.rb
@@ -1,0 +1,5 @@
+class AddStatusToActivities < ActiveRecord::Migration[7.1]
+  def change
+    add_column :activities, :activity_status, :string, default: 'planned'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_03_13_114145) do
+ActiveRecord::Schema[7.1].define(version: 2025_03_15_100458) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -54,6 +54,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_13_114145) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "activity_type"
+    t.string "activity_status", default: "planned"
     t.index ["child_id"], name: "index_activities_on_child_id"
     t.index ["educator_id"], name: "index_activities_on_educator_id"
     t.index ["relative_id"], name: "index_activities_on_relative_id"


### PR DESCRIPTION
First card of the agenda is fixed when "in progress", the other cards can sweep under when scrolling down.
Button added to allow user to display more details on selected activity, 
User can choose to start an activity on the detailled view, status is updated and indication on the button changes.
User can fold or unfold the details through the arrow button, that turns in the direction  of the action (up or down)
When user declares that an activity is finished, the card is no longer displayed and the button starts is available on the next card of activity.
![image](https://github.com/user-attachments/assets/0c4d8648-ba50-4fad-b160-af64973125bc)
![image](https://github.com/user-attachments/assets/bd85e459-5658-4e4f-acf2-ee6b27a03d2a)

