### PR TITLE
Seeds for demo day and freetime between cards in agenda

### DIFF
--- a/app/assets/stylesheets/components/_card_agenda.scss
+++ b/app/assets/stylesheets/components/_card_agenda.scss
@@ -10,7 +10,7 @@
 .card-agenda {
   position: relative;
   min-height: fit-content;
-  // padding: 1px;
+  padding: 1px;
   border-radius: 5px;
   width: 100%;
   border: 1px solid $dark-blue;
@@ -36,7 +36,7 @@
   background-color: white;
   height: $time-height;
   width: 65px;
-  border-radius: 0% 0% 5% 5% / 0% 0% 10% 5%  ;
+  border-radius: 5px;
   text-align: center;
   justify-content: center;
   align-items: center;

--- a/app/assets/stylesheets/components/_card_agenda.scss
+++ b/app/assets/stylesheets/components/_card_agenda.scss
@@ -3,15 +3,15 @@
 }
 //  class of the div for JS controller
 .a-dallas {
-  margin-left: 15px;
-  margin-right: 15px;
+  // margin-left: 15px;
+  // margin-right: 15px;
 }
 
 .card-agenda {
   position: relative;
   min-height: fit-content;
-  padding: 1px;
-  border-radius: 5px;
+  // padding: 1px;
+  // border-radius: 5px;
   width: 100%;
   border: 1px solid $dark-blue;
   display: block;
@@ -36,7 +36,7 @@
   background-color: white;
   height: $time-height;
   width: 65px;
-  border-radius: 5px;
+  border-radius: 0% 0% 5% 5% / 0% 0% 10% 5%  ;
   text-align: center;
   justify-content: center;
   align-items: center;

--- a/app/assets/stylesheets/components/_card_agenda.scss
+++ b/app/assets/stylesheets/components/_card_agenda.scss
@@ -11,7 +11,7 @@
   position: relative;
   min-height: fit-content;
   // padding: 1px;
-  // border-radius: 5px;
+  border-radius: 5px;
   width: 100%;
   border: 1px solid $dark-blue;
   display: block;

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -6,7 +6,7 @@ class Activity < ApplicationRecord
 
    # enumerable pour stocker les types d'activités
   # /!\ stocké en integer dans bdd donc ds table activity: t.integer "activity_type"
-  enum activity_type: %i[journey activity breaktime nothingplanned]
+  enum activity_type: %i[journey activity breaktime]
 
   # on indique en validation du activity_type la liste des clés de user_typeS
   validates :activity_type, inclusion: { in: Activity.activity_types.keys }

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -6,9 +6,9 @@ class Activity < ApplicationRecord
 
    # enumerable pour stocker les types d'activités
   # /!\ stocké en integer dans bdd donc ds table activity: t.integer "activity_type"
-  enum activity_type: %i[journey activity breaktime]
+  enum activity_type: %i[journey activity breaktime nothingplanned]
 
   # on indique en validation du activity_type la liste des clés de user_typeS
   validates :activity_type, inclusion: { in: Activity.activity_types.keys }
-  # ajouter presence: true quand les seeds seront créées avec cette column 
+  # ajouter presence: true quand les seeds seront créées avec cette column
 end

--- a/app/views/activities/mes_activites.html.erb
+++ b/app/views/activities/mes_activites.html.erb
@@ -23,28 +23,39 @@
   <% end %>
   <%# displays all the cards of activities  %>
   <%# note that the first one is the activity in progress, displayed behind the previous one fixed %>
+  <% du_plombier = [] %>
   <% @activities.each do |activity| %>
+    <% duration = activity.ending_date - activity.starting_date %>
     <% if activity.activity_status != "finished" %>
-        <div class="card-agenda <%=activity.activity_type%>"
-            data-controller="toggle-details"
-              style="height:  <%= (activity.ending_date - activity.starting_date)/40%>px">
-          <div class = "starting-time">
-              <p><%= activity.starting_date.strftime("%H:%M")  %></p>
-          </div>
-          <div class="card-header">
-            <div class= "activity-name"><%= activity.name %></div>
-            <button data-action="click->toggle-details#display"
-                    data-toggle-details-activity-id-param="<%= activity.id %>"
-                    class="btn toggle-details">
-              <i class="fa-solid fa-caret-down" data-toggle-details-target="caretIcon"></i>
-            </button>
-          </div>
-          <%# the rest of the information of the activity is displayed on demand %>
-          <div data-toggle-details-target="togglableElement"
-              class="card-body d-none">
-            <%= render "activity_details", activity: activity  %>
-          </div>
+      <%# Checks if there was an activity created previously  %>
+      <% if du_plombier.any? %>
+        <% last_activity_ending = du_plombier.pop %>
+        <% freetime = activity.starting_date - last_activity_ending %>
+        <%# create an empty space proportional to time with nothing planned with minimum 4px %>
+        <div style="height: <%= (freetime/40 < 4) ? 4 : (freetime/40) %>px"></div>
+      <% end %>
+      <div class="card-agenda <%=activity.activity_type%>"
+          data-controller="toggle-details"
+            style="height:  <%= duration/40 %>px">
+        <div class = "starting-time">
+            <p><%= activity.starting_date.strftime("%H:%M")  %></p>
         </div>
+        <div class="card-header">
+          <div class= "activity-name"><%= activity.name %></div>
+          <button data-action="click->toggle-details#display"
+                  data-toggle-details-activity-id-param="<%= activity.id %>"
+                  class="btn toggle-details">
+            <i class="fa-solid fa-caret-down" data-toggle-details-target="caretIcon"></i>
+          </button>
+        </div>
+        <%# the rest of the information of the activity is displayed on demand %>
+        <div data-toggle-details-target="togglableElement"
+            class="card-body d-none">
+          <%= render "activity_details", activity: activity  %>
+        </div>
+      </div>
+      <%# keep the ending date of this activity to compare with the next one %>
+      <% du_plombier << activity.ending_date %>
     <% end %> <%# close the condition if status not finished  %>
   <% end %> <%# Close the each loop %>
   </div>

--- a/db/data/college_seeds.csv
+++ b/db/data/college_seeds.csv
@@ -1,16 +1,16 @@
-name;activity_type;heure_debut;starting_time;duree;duration;description;child_id;educator_id;relative_id;picture
-Trajet college;journey;07:15;26100;00:30;26100;Partir a l'heure!;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;college_jiemug
-Mathematiques;activity;08:00;28800;00:55;28800;Les geometrie et figures planesLes angles : types d'angles (aigus, droits, obtus), propriétées des angles opposes par le sommet, calcul des angles dans des figures simples;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;cours_maths_jtebnf
-Francais;activity;09:00;32400;00:55;32400; Lecture et comprehension de textes: Analyser le vocabulaire, les personnages, le cadre, et la structure du texte. Signification du texte, en utilisant des citations pour justifier leurs reponses.;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;cours_francais_fdeyk0
-Recreation;breaktime;09:55;35700;00:15;35700;Aller aux WC.;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;recreation_uhj8un
-Histoire;activity;10:10;36600;00:55;36600;Les grandes decouvertes et la Renaissance (XVe - XVIe siecles): L'exploration du monde par des navigateurs comme Christophe Colomb (1492) ou Vasco de Gama. L'invention de l'imprimerie par Johannes Gutenberg et les avancees dans des domaines comme l'astronomie, les mathematiques et la m�decine.;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;cours_histoire_tlsvxi
-Anglais;activity;11:10;40200;00:55;40200;Vocabulaire:  situations de la vie quotidienne, comme les descriptions physiques et de personnalit�, les objets de la maison, les emotions, les metiers, les saisons, les animaux. Exercices pratiques :  jeux de mots, des cartes memoire (flashcards).;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;classe_geographie_wdumh3
-Cantine;activity;12:10;43800;00:50;43800;Miam miam;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;cantine_eek480
-Sport;activity;13:30;48600;01:25;48600;Activite : ping-pong;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;pingpong_mpwidx
-Soutien scolaire;activity;15:00;54000;00:55;54000;Exercices du jour, revision des cours pour le lendemain;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;cours_maths_jtebnf
-Trajet maison;journey;16:00;57600;00:30;57600;Attention aux velos sur la route;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;maison_j3nvou
-Gouter;breaktime;16:30;59400;00:20;59400;Miam miam;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;repas_dm1z4l
-Douche;activity;18:00;64800;00:30;64800;Shampoing doux qui ne pique pas les yeux;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;sdb_adclbw
-Repas;activity;19:00;68400;00:45;68400;Miam miam;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;repas_dm1z4l
-Tv;breaktime;19:45;71100;01:00;71100;Questions pour un champion (rediff);Child.last.id;Educator.all.sample.id;Relative.all.sample.id;salontv_yjuodu
-Salle de bain;activity;20:45;74700;00:10;74700;Brossage de dent;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;sdb_adclbw
+name;activity_type;heure_debut;starting_time;duree;duration;description;picture
+Trajet college;journey;07:15;26100;00:30;1800;Partir a l'heure!;college_jiemug
+Mathematiques;activity;08:00;28800;00:55;3300;Les angles : types d'angles (aigus, droits, obtus), proprietées des angles opposes par le sommet, calcul des angles dans des figures simples.;cours_maths_jtebnf
+Francais;activity;09:00;32400;00:55;3300; Lecture et comprehension de textes: Analyser le vocabulaire, les personnages, le cadre, et la structure du texte. Signification du texte, en utilisant des citations pour justifier leurs reponses.;cours_francais_fdeyk0
+Recreation;breaktime;09:55;35700;00:15;900;Aller aux WC.;recreation_uhj8un
+Histoire;activity;10:10;36600;00:55;3300;Les grandes decouvertes et la Renaissance (XVe - XVIe siecles): L'exploration du monde par des navigateurs comme Christophe Colomb (1492) ou Vasco de Gama. L'invention de l'imprimerie par Johannes Gutenberg et les avancees dans des domaines comme l'astronomie, les mathematiques et la médecine.;cours_histoire_tlsvxi
+Anglais;activity;11:10;40200;00:55;3300;Vocabulaire:  situations de la vie quotidienne, comme les descriptions physiques et de personnalité, les objets de la maison, les emotions, les metiers, les saisons, les animaux. Exercices pratiques :  jeux de mots, des cartes memoire (flashcards).;classe_geographie_wdumh3
+Cantine;activity;12:10;43800;00:50;3000;Miam miam;cantine_eek480
+Sport;activity;13:30;48600;01:25;5100;Activite : ping-pong;pingpong_mpwidx
+Soutien scolaire;activity;15:00;54000;00:55;3300;Exercices du jour, revision des cours pour le lendemain;cours_maths_jtebnf
+Trajet maison;journey;16:00;57600;00:30;1800;Attention aux velos sur la route;maison_j3nvou
+Gouter;breaktime;16:30;59400;00:20;1200;Miam miam;repas_dm1z4l
+Douche;activity;18:00;64800;00:30;1800;Shampoing doux qui ne pique pas les yeux;sdb_adclbw
+Repas;activity;19:00;68400;00:45;2700;Miam miam;repas_dm1z4l
+Tv;breaktime;19:45;71100;01:00;3600;Questions pour un champion (rediff);salontv_yjuodu
+Salle de bain;activity;20:45;74700;00:10;600;Brossage de dent;sdb_adclbw

--- a/db/data/college_seeds.csv
+++ b/db/data/college_seeds.csv
@@ -1,0 +1,18 @@
+name;activity_type;starting_time;duration;description;child_id;educator_id;relative_id;picture
+Trajet college;journey;07:15;00:30;;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;college_jiemug
+Mathematiques;activity;08:00;00:55;"Les geometrie et figures planes
+Les angles : types d'angles (aigus, droits, obtus), propriete‚ des angles opposes par le sommet, calcul des angles dans des figures simples.
+";Child.last.id;Educator.all.sample.id;Relative.all.sample.id;cours_maths_jtebnf
+Francais;activity;09:00;00:55; Lecture et comprehension de textes: Analyser le vocabulaire, les personnages, le cadre, et la structure du texte. Signification du texte, en utilisant des citations pour justifier leurs reponses.;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;cours_francais_fdeyk0
+Recreation;breaktime;09:55;00:15;Aller aux WC.;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;recreation_uhj8un
+Histoire;activity;10:10;00:55;Les grandes decouvertes et la Renaissance (XVe - XVIe siecles): L'exploration du monde par des navigateurs comme Christophe Colomb (1492) ou Vasco de Gama. L'invention de l'imprimerie par Johannes Gutenberg et les avancees dans des domaines comme l'astronomie, les mathematiques et la m‚decine.;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;cours_histoire_tlsvxi
+Anglais;activity;11:10;00:55;Vocabulaire:  situations de la vie quotidienne, comme les descriptions physiques et de personnalit‚, les objets de la maison, les emotions, les metiers, les saisons, les animaux. Exercices pratiques :  jeux de mots, des cartes memoire (flashcards).;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;classe_geographie_wdumh3
+Cantine;activity;12:10;00:50;;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;cantine_eek480
+Sport;activity;13:30;01:25;Activite : ping-pong;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;pingpong_mpwidx
+Soutien scolaire;activity;15:00;00:55;Exercices du jour, revision des cours pour le lendemain;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;cours_maths_jtebnf
+Trajet maison;journey;16:00;00:30;;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;maison_j3nvou
+Gouter;breaktime;16:30;00:20;;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;repas_dm1z4l
+Douche;activity;18:00;00:30;;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;sdb_adclbw
+Repas;activity;19:00;00:45;;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;repas_dm1z4l
+Tv;breaktime;19:45;01:00;;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;salontv_yjuodu
+Salle de bain;activity;20:45;00:10;Brossage de dent;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;sdb_adclbw

--- a/db/data/college_seeds.csv
+++ b/db/data/college_seeds.csv
@@ -1,18 +1,16 @@
-name;activity_type;starting_time;duration;description;child_id;educator_id;relative_id;picture
-Trajet college;journey;07:15;00:30;;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;college_jiemug
-Mathematiques;activity;08:00;00:55;"Les geometrie et figures planes
-Les angles : types d'angles (aigus, droits, obtus), propriete‚ des angles opposes par le sommet, calcul des angles dans des figures simples.
-";Child.last.id;Educator.all.sample.id;Relative.all.sample.id;cours_maths_jtebnf
-Francais;activity;09:00;00:55; Lecture et comprehension de textes: Analyser le vocabulaire, les personnages, le cadre, et la structure du texte. Signification du texte, en utilisant des citations pour justifier leurs reponses.;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;cours_francais_fdeyk0
-Recreation;breaktime;09:55;00:15;Aller aux WC.;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;recreation_uhj8un
-Histoire;activity;10:10;00:55;Les grandes decouvertes et la Renaissance (XVe - XVIe siecles): L'exploration du monde par des navigateurs comme Christophe Colomb (1492) ou Vasco de Gama. L'invention de l'imprimerie par Johannes Gutenberg et les avancees dans des domaines comme l'astronomie, les mathematiques et la m‚decine.;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;cours_histoire_tlsvxi
-Anglais;activity;11:10;00:55;Vocabulaire:  situations de la vie quotidienne, comme les descriptions physiques et de personnalit‚, les objets de la maison, les emotions, les metiers, les saisons, les animaux. Exercices pratiques :  jeux de mots, des cartes memoire (flashcards).;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;classe_geographie_wdumh3
-Cantine;activity;12:10;00:50;;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;cantine_eek480
-Sport;activity;13:30;01:25;Activite : ping-pong;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;pingpong_mpwidx
-Soutien scolaire;activity;15:00;00:55;Exercices du jour, revision des cours pour le lendemain;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;cours_maths_jtebnf
-Trajet maison;journey;16:00;00:30;;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;maison_j3nvou
-Gouter;breaktime;16:30;00:20;;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;repas_dm1z4l
-Douche;activity;18:00;00:30;;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;sdb_adclbw
-Repas;activity;19:00;00:45;;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;repas_dm1z4l
-Tv;breaktime;19:45;01:00;;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;salontv_yjuodu
-Salle de bain;activity;20:45;00:10;Brossage de dent;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;sdb_adclbw
+name;activity_type;heure_debut;starting_time;duree;duration;description;child_id;educator_id;relative_id;picture
+Trajet college;journey;07:15;26100;00:30;26100;Partir a l'heure!;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;college_jiemug
+Mathematiques;activity;08:00;28800;00:55;28800;Les geometrie et figures planesLes angles : types d'angles (aigus, droits, obtus), propriÃ©tÃ©es des angles opposes par le sommet, calcul des angles dans des figures simples;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;cours_maths_jtebnf
+Francais;activity;09:00;32400;00:55;32400; Lecture et comprehension de textes: Analyser le vocabulaire, les personnages, le cadre, et la structure du texte. Signification du texte, en utilisant des citations pour justifier leurs reponses.;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;cours_francais_fdeyk0
+Recreation;breaktime;09:55;35700;00:15;35700;Aller aux WC.;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;recreation_uhj8un
+Histoire;activity;10:10;36600;00:55;36600;Les grandes decouvertes et la Renaissance (XVe - XVIe siecles): L'exploration du monde par des navigateurs comme Christophe Colomb (1492) ou Vasco de Gama. L'invention de l'imprimerie par Johannes Gutenberg et les avancees dans des domaines comme l'astronomie, les mathematiques et la mï¿½decine.;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;cours_histoire_tlsvxi
+Anglais;activity;11:10;40200;00:55;40200;Vocabulaire:  situations de la vie quotidienne, comme les descriptions physiques et de personnalitï¿½, les objets de la maison, les emotions, les metiers, les saisons, les animaux. Exercices pratiques :  jeux de mots, des cartes memoire (flashcards).;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;classe_geographie_wdumh3
+Cantine;activity;12:10;43800;00:50;43800;Miam miam;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;cantine_eek480
+Sport;activity;13:30;48600;01:25;48600;Activite : ping-pong;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;pingpong_mpwidx
+Soutien scolaire;activity;15:00;54000;00:55;54000;Exercices du jour, revision des cours pour le lendemain;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;cours_maths_jtebnf
+Trajet maison;journey;16:00;57600;00:30;57600;Attention aux velos sur la route;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;maison_j3nvou
+Gouter;breaktime;16:30;59400;00:20;59400;Miam miam;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;repas_dm1z4l
+Douche;activity;18:00;64800;00:30;64800;Shampoing doux qui ne pique pas les yeux;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;sdb_adclbw
+Repas;activity;19:00;68400;00:45;68400;Miam miam;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;repas_dm1z4l
+Tv;breaktime;19:45;71100;01:00;71100;Questions pour un champion (rediff);Child.last.id;Educator.all.sample.id;Relative.all.sample.id;salontv_yjuodu
+Salle de bain;activity;20:45;74700;00:10;74700;Brossage de dent;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;sdb_adclbw

--- a/db/data/today_seeds.csv
+++ b/db/data/today_seeds.csv
@@ -1,0 +1,16 @@
+name;activity_type;starting_time;duration;description;child_id;educator_id;relative_id;picture
+Trajet wagon;journey;08:15;00:30;;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;lewagonbordeaux_m1xrrx_taille_copilot_gl1vwn
+Daily review;activity;09:00;00:55;;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;cours_maths_jtebnf
+Debug agenda;activity;09:00;00:55;;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;cours_francais_fdeyk0
+Pause cafe;breaktime;09:55;00:15;;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;recreation_uhj8un
+Debug;activity;10:10;00:55;;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;cours_histoire_tlsvxi
+Live Code;activity;11:10;00:55;Vocabulaire:  situations de la vie quotidienne, comme les descriptions physiques et de personnalite, les objets de la maison, les �motions, les metiers, les saisons, les animaux. Exercices pratiques :  jeux de mots, des cartes memoire (flashcards).;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;classe_geographie_wdumh3
+Cantine;activity;12:10;00:50;;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;cantine_eek480
+Prepatation demo;activity;13:30;01:25;Activite : ping-pong;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;pingpong_mpwidx
+Repetition scenario;activity;15:00;00:55;Exercices du jour, revision des cours pour le lendemain;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;cours_maths_jtebnf
+Trajet maison;journey;16:00;00:30;;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;maison_j3nvou
+Gouter;breaktime;16:30;00:20;;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;repas_dm1z4l
+Trajet wagon;journey;18:00;00:30;;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;lewagonbordeaux_m1xrrx_taille_copilot_gl1vwn
+Demo Day;activity;18:30;01:30;Presentation des projets des bootcamp: Developpeur web, Data Analyst, Data Scientist.;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;lewagonbordeaux_m1xrrx_taille_copilot_gl1vwn
+Trajet maison;journey;20:00;00:30;;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;maison_j3nvou
+Salle de bain;activity;20:45;00:10;Brossage de dent;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;sdb_adclbw

--- a/db/data/today_seeds.csv
+++ b/db/data/today_seeds.csv
@@ -1,16 +1,16 @@
-name;activity_type;starting_time;duration;description;child_id;educator_id;relative_id;picture
-Trajet wagon;journey;08:15;00:30;;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;lewagonbordeaux_m1xrrx_taille_copilot_gl1vwn
-Daily review;activity;09:00;00:55;;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;cours_maths_jtebnf
-Debug agenda;activity;09:00;00:55;;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;cours_francais_fdeyk0
-Pause cafe;breaktime;09:55;00:15;;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;recreation_uhj8un
-Debug;activity;10:10;00:55;;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;cours_histoire_tlsvxi
-Live Code;activity;11:10;00:55;Vocabulaire:  situations de la vie quotidienne, comme les descriptions physiques et de personnalite, les objets de la maison, les �motions, les metiers, les saisons, les animaux. Exercices pratiques :  jeux de mots, des cartes memoire (flashcards).;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;classe_geographie_wdumh3
-Cantine;activity;12:10;00:50;;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;cantine_eek480
-Prepatation demo;activity;13:30;01:25;Activite : ping-pong;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;pingpong_mpwidx
-Repetition scenario;activity;15:00;00:55;Exercices du jour, revision des cours pour le lendemain;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;cours_maths_jtebnf
-Trajet maison;journey;16:00;00:30;;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;maison_j3nvou
-Gouter;breaktime;16:30;00:20;;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;repas_dm1z4l
-Trajet wagon;journey;18:00;00:30;;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;lewagonbordeaux_m1xrrx_taille_copilot_gl1vwn
-Demo Day;activity;18:30;01:30;Presentation des projets des bootcamp: Developpeur web, Data Analyst, Data Scientist.;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;lewagonbordeaux_m1xrrx_taille_copilot_gl1vwn
-Trajet maison;journey;20:00;00:30;;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;maison_j3nvou
-Salle de bain;activity;20:45;00:10;Brossage de dent;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;sdb_adclbw
+name;activity_type;heure_debut;starting_time;duree;duration;description;child_id;educator_id;relative_id;picture
+Trajet wagon;journey;08:15:00;29700;00:30:00;1800;Tramway;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;lewagonbordeaux_m1xrrx_taille_copilot_gl1vwn
+Daily review;activity;09:00:00;32400;00:55:00;3300;Avec toute l equipe;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;cours_maths_jtebnf
+Debug agenda;activity;09:00:00;32400;00:55:00;3300;courage !;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;cours_francais_fdeyk0
+Pause cafe;breaktime;09:55:00;35700;00:15:00;900;petit mate;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;recreation_uhj8un
+Debug;activity;10:10:00;36600;00:55:00;3300;c'est reparti;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;cours_histoire_tlsvxi
+Live Code;activity;11:10:00;40200;00:55:00;3300;Vocabulaire: situations de la vie quotidienne, comme les descriptions physiques et de personnalite, les objets de la maison, les emotions, les metiers, les saisons, les animaux. Exercices pratiques :  jeux de mots, des cartes memoire (flashcards).;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;classe_geographie_wdumh3
+Cantine;activity;12:10:00;43800;00:50:00;3000;miam;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;cantine_eek480
+Préparation demo;activity;13:30:00;48600;01:25:00;5100;Activite : ping-pong;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;pingpong_mpwidx
+Répetition scenario;activity;15:00:00;54000;00:55:00;3300;Exercices du jour, revision des cours pour le lendemain;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;cours_maths_jtebnf
+Trajet maison;journey;16:00:00;57600;00:30:00;1800;Tramway;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;maison_j3nvou
+Gouter;breaktime;16:30:00;59400;00:20:00;1200;miam;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;repas_dm1z4l
+Trajet wagon;journey;18:00:00;64800;00:30:00;1800;Tramway;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;lewagonbordeaux_m1xrrx_taille_copilot_gl1vwn
+Demo Day;activity;18:30:00;66600;01:30:00;5400;Présentation des projets des bootcamp: Developpeur web, Data Analyst, Data Scientist.;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;lewagonbordeaux_m1xrrx_taille_copilot_gl1vwn
+Trajet maison;journey;20:00:00;72000;00:30:00;1800;Tramway;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;maison_j3nvou
+Salle de bain;activity;20:45:00;74700;00:10:00;600;Brossage de dent;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;sdb_adclbw

--- a/db/data/today_seeds.csv
+++ b/db/data/today_seeds.csv
@@ -1,16 +1,16 @@
-name;activity_type;heure_debut;starting_time;duree;duration;description;child_id;educator_id;relative_id;picture
-Trajet wagon;journey;08:15:00;29700;00:30:00;1800;Tramway;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;lewagonbordeaux_m1xrrx_taille_copilot_gl1vwn
-Daily review;activity;09:00:00;32400;00:55:00;3300;Avec toute l equipe;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;cours_maths_jtebnf
-Debug agenda;activity;09:00:00;32400;00:55:00;3300;courage !;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;cours_francais_fdeyk0
-Pause cafe;breaktime;09:55:00;35700;00:15:00;900;petit mate;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;recreation_uhj8un
-Debug;activity;10:10:00;36600;00:55:00;3300;c'est reparti;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;cours_histoire_tlsvxi
-Live Code;activity;11:10:00;40200;00:55:00;3300;Vocabulaire: situations de la vie quotidienne, comme les descriptions physiques et de personnalite, les objets de la maison, les emotions, les metiers, les saisons, les animaux. Exercices pratiques :  jeux de mots, des cartes memoire (flashcards).;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;classe_geographie_wdumh3
-Cantine;activity;12:10:00;43800;00:50:00;3000;miam;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;cantine_eek480
-Préparation demo;activity;13:30:00;48600;01:25:00;5100;Activite : ping-pong;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;pingpong_mpwidx
-Répetition scenario;activity;15:00:00;54000;00:55:00;3300;Exercices du jour, revision des cours pour le lendemain;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;cours_maths_jtebnf
-Trajet maison;journey;16:00:00;57600;00:30:00;1800;Tramway;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;maison_j3nvou
-Gouter;breaktime;16:30:00;59400;00:20:00;1200;miam;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;repas_dm1z4l
-Trajet wagon;journey;18:00:00;64800;00:30:00;1800;Tramway;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;lewagonbordeaux_m1xrrx_taille_copilot_gl1vwn
-Demo Day;activity;18:30:00;66600;01:30:00;5400;Présentation des projets des bootcamp: Developpeur web, Data Analyst, Data Scientist.;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;lewagonbordeaux_m1xrrx_taille_copilot_gl1vwn
-Trajet maison;journey;20:00:00;72000;00:30:00;1800;Tramway;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;maison_j3nvou
-Salle de bain;activity;20:45:00;74700;00:10:00;600;Brossage de dent;Child.last.id;Educator.all.sample.id;Relative.all.sample.id;sdb_adclbw
+name;activity_type;heure_debut;starting_time;duree;duration;description;picture
+Trajet wagon;journey;08:15:00;29700;00:30:00;1800;Tramway;lewagonbordeaux_m1xrrx_taille_copilot_gl1vwn
+Daily review;activity;09:00:00;32400;00:55:00;3300;Avec toute l'equipe;cours_maths_jtebnf
+Pause cafe;breaktime;09:55:00;35700;00:15:00;900;petit mate;recreation_uhj8un
+Debug;activity;10:10:00;36600;00:55:00;3300;c est reparti;cours_histoire_tlsvxi
+Live Code;activity;11:10:00;40200;00:55:00;3300;Vocabulaire:  situations de la vie quotidienne, comme les descriptions physiques et de personnalité, les objets de la maison, les émotions, les métiers, les saisons, les animaux. Exercices pratiques :  jeux de mots, des cartes mémoire (flashcards).;classe_geographie_wdumh3
+Cantine;activity;12:10:00;43800;00:50:00;3000;miam;cantine_eek480
+Prepatation demo;activity;13:30:00;48600;01:25:00;5100;Activité: ping-pong;pingpong_mpwidx
+Repetition scenario;activity;15:00:00;54000;00:55:00;3300;Exercices du jour, revision des cours pour le lendemain;cours_maths_jtebnf
+Trajet maison;journey;16:00:00;57600;00:30:00;1800;Tramway;maison_j3nvou
+Gouter;breaktime;16:30:00;59400;00:20:00;1200;miam;repas_dm1z4l
+Trajet wagon;journey;18:00:00;64800;00:30:00;1800;Tramway;lewagonbordeaux_m1xrrx_taille_copilot_gl1vwn
+Demo Day;activity;18:30:00;66600;01:30:00;5400;Présentation des projets des bootcamp: Developpeur web, Data Analyst, Data Scientist.;lewagonbordeaux_m1xrrx_taille_copilot_gl1vwn
+repas;breaktime;19:30:00;70200;00:30:00;1800;Buffet offert par le wagon;repas_dm1z4l
+Trajet maison;journey;20:00:00;72000;00:30:00;1800;Tramway;maison_j3nvou
+Salle de bain;activity;20:45:00;74700;00:10:00;600;Brossage de dent;sdb_adclbw

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -204,8 +204,8 @@ filetoday = Rails.root.join('db', 'data', 'today_seeds.csv')
 filecollege = Rails.root.join('db', 'data', 'college_seeds.csv')
 
 # Initialisation de la date du jour (démarrant à 00:00:00)
-TODAY = Date.today.to_time # on considère qu'aujourd'hui c'est vendredi :-)
-MONDAY = TODAY + 86400*2     # donc dans deux jours c'est lundi :-)
+TODAY = Date.today.to_time + 3600 # on considère qu'aujourd'hui c'est vendredi :-)
+MONDAY = TODAY + 86400*2    # donc dans deux jours c'est lundi :-)
 # puts TODAY
 # puts filetoday
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -31,7 +31,7 @@ User.create(
   last_name:"Martin",
   address: "15 rue Baste, 33300 Bordeaux",
   userable: Child.create
-)
+  )
 file = URI.parse(Cloudinary::Utils.cloudinary_url("Simon_t7r62g")).open
   User.last.photo.attach(io: file, filename: "#{User.last.first_name}.jpeg", content_type:"image/jpeg")
   User.last.save
@@ -201,20 +201,23 @@ puts "Création des activités d'une journée courte"
 # end
 
 
-filetoday = "data/today_seeds.csv"
-filecollege = "data/college_seeds.csv"
+filetoday = Rails.root.join('db', 'data', 'today_seeds.csv')
+filecollege = Rails.root.join('db', 'data', 'college_seeds.csv')
 
 # Initialisation de la date du jour (démarrant à 00:00:00)
-TODAY = DateTime.tomorrow.to_time
+TODAY = Date.today.to_time # on considère qu'aujourd'hui c'est vendredi :-)
+MONDAY = TODAY + 86400*2     # donc dans deux jours c'est lundi :-)
+# puts TODAY
+# puts filetoday
 
 # Creation des activité spécifiques à la journée demo day
-CSV.foreach(filetoday, headers: :first_row) do |row|
+CSV.foreach(filetoday, headers: :first_row, col_sep: ';') do |row|
   today_activity = Activity.new(
     name: row['name'],
     activity_type: row['activity_type'],
     description: row['description'],
-    starting_date: TODAY + row['starting_time'],
-    ending_date: TODAY + row['starting_time'] + row['duration'],
+    starting_date: TODAY + row['starting_time'].to_i,
+    ending_date: TODAY + row['starting_time'].to_i + row['duration'].to_i,
     child_id: Child.last.id,
     educator_id: Educator.all.sample.id,
     relative_id: Relative.all.sample.id
@@ -223,4 +226,26 @@ CSV.foreach(filetoday, headers: :first_row) do |row|
   today_activity.photo.attach(io: file, filename: "#{today_activity.name}.jpeg", content_type:"image/jpeg")
   today_activity.save
   puts "#{today_activity.name} créé"
+end
+
+# Creation des activités d'une semaine au collège
+day = MONDAY
+1.times do
+  CSV.foreach(filecollege, headers: :first_row, col_sep: ';') do |row|
+    college_activity = Activity.new(
+      name: row['name'],
+      activity_type: row['activity_type'],
+      description: row['description'],
+      starting_date: day + row['starting_time'].to_i,
+      ending_date: day + row['starting_time'].to_i + row['duration'].to_i,
+      child_id: Child.last.id,
+      educator_id: Educator.all.sample.id,
+      relative_id: Relative.all.sample.id
+    )
+    file = URI.parse(Cloudinary::Utils.cloudinary_url(row['picture'])).open
+    college_activity.photo.attach(io: file, filename: "#{college_activity.name}.jpeg", content_type: "image/jpeg")
+    college_activity.save
+    puts "#{college_activity.name} créé"
+  end
+  day += 1
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -200,7 +200,6 @@ puts "Création des activités d'une journée courte"
 #   puts "#{activite.name} créé"
 # end
 
-
 filetoday = Rails.root.join('db', 'data', 'today_seeds.csv')
 filecollege = Rails.root.join('db', 'data', 'college_seeds.csv')
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,6 +11,8 @@
 require "open-uri"
 # Pour pouvoir générer des dates d'activités
 require 'date'
+# Pour parser les fichiers avec les utilisateurs et toutes les activités
+require "csv"
 
 #Nettoyage de la base (efface les users de la DB avant d'en créer de nouveaux)
 Activity.destroy_all
@@ -33,7 +35,7 @@ User.create(
 file = URI.parse(Cloudinary::Utils.cloudinary_url("Simon_t7r62g")).open
   User.last.photo.attach(io: file, filename: "#{User.last.first_name}.jpeg", content_type:"image/jpeg")
   User.last.save
-puts "Simon a été créé"
+puts "#{User.last.first_name} a été créé"
 
 # création du user Père
 User.create(
@@ -68,7 +70,7 @@ User.create(
   password:"123456",
   email: "michel@lewagon.org",
   first_name: "Michel",
-  last_name:"Michel",
+  last_name:"Carpaccio",
   address: "12 rue Paul Berthelot, 33300 Bordeaux",
   userable: Educator.create
 )
@@ -172,29 +174,53 @@ puts "Jessica (educatrice) a été créé"
 
 puts "Création des activités d'une journée courte"
 
-LIST_ACTIVITIES = %w[Trajet_aller Mathematiques Français Recreation Histoire Cantine Geographie Sport Ping_Pong Gaming DemoDay Trajet_retour  Salle_de_bain Repas Tv]
-LIST_DESCRIPTIONS = %w[Matin Salle_204 Salle_140 Cour_Collège Salle_129 Réfectoire Salle_224 Sport_GymnaseA Entrainement Jeux_PC DemoDay_leWagon Soir  Douche Repas_Famille EmissionTv]
-LIST_PICTURES = %w[college_jiemug cours_maths_jtebnf cours_francais_fdeyk0 récréation_uhj8un cours_histoire_tlsvxi cantine_eek480 classe_géographie_wdumh3 gymnase_kvsgdc pingpong_mpwidx gaming_xxtqo7 lewagonbordeaux_m1xrrx_taille_copilot_gl1vwn maison_j3nvou  sdb_adclbw repas_dm1z4l salontv_yjuodu]
-LIST_ACTIV_TYPES = %w[journey activity activity breaktime activity breaktime activity activity activity activity activity journey   activity activity breaktime]
-LIST_DURATION = %w[1800 3600 3600 1800 5400 3600 5400 5400 3600 3600 1800 1800 1800 1800 5400]
+# LIST_ACTIVITIES = ["Trajet collège", "Mathematiques", "Français", "Recreation", "Histoire", "Cantine", "Geographie", "Sport", "Ping Pong", "Gaming", "DemoDay", "Trajet de retour",  "Salle de bain", "Repas", "Tv"]
+# LIST_DESCRIPTIONS = %w[Matin Salle_204 Salle_140 Cour_Collège Salle_129 Réfectoire Salle_224 Sport_GymnaseA Entrainement Jeux_PC DemoDay_leWagon Soir  Douche Repas_Famille EmissionTv]
+# LIST_PICTURES = %w[college_jiemug cours_maths_jtebnf cours_francais_fdeyk0 récréation_uhj8un cours_histoire_tlsvxi cantine_eek480 classe_géographie_wdumh3 gymnase_kvsgdc pingpong_mpwidx gaming_xxtqo7 lewagonbordeaux_m1xrrx_taille_copilot_gl1vwn maison_j3nvou  sdb_adclbw repas_dm1z4l salontv_yjuodu]
+# LIST_ACTIV_TYPES = %w[journey activity activity breaktime activity breaktime activity activity activity activity activity journey   activity activity breaktime]
+# LIST_DURATION = %w[1800 3600 3600 1800 5400 3600 5400 5400 3600 3600 1800 1800 1800 1800 5400]
 
-DAY_STARTS_AT = DateTime.tomorrow.to_time + 8 * 3600
+# DAY_STARTS_AT = DateTime.tomorrow.to_time + 8 * 3600
 
-LIST_ACTIVITIES.each_with_index do |activite, index|
-  activite = Activity.new(
-    name: LIST_ACTIVITIES[index],
-    starting_date: DAY_STARTS_AT + (index * 3600),
-    ending_date: DAY_STARTS_AT + (index * 3600) + (LIST_DURATION[index].to_i),
-    like: true,
-    description: LIST_DESCRIPTIONS[index],
-    # activity_pic_id: "",
+# LIST_ACTIVITIES.each_with_index do |activite, index|
+#   activite = Activity.new(
+#     name: LIST_ACTIVITIES[index],
+#     starting_date: DAY_STARTS_AT + (index * 3600),
+#     ending_date: DAY_STARTS_AT + (index * 3600) + (LIST_DURATION[index].to_i),
+#     like: true,
+#     description: LIST_DESCRIPTIONS[index],
+#     child_id: Child.last.id,
+#     educator_id: Educator.all.sample.id,
+#     relative_id: Relative.all.sample.id,
+#     activity_type: LIST_ACTIV_TYPES[index]
+#   )
+#   file = URI.parse(Cloudinary::Utils.cloudinary_url(LIST_PICTURES[index])).open
+#   activite.photo.attach(io: file, filename: "#{LIST_ACTIVITIES[index]}.jpeg", content_type:"image/jpeg")
+#   activite.save
+#   puts "#{activite.name} créé"
+# end
+
+
+filetoday = "data/today_seeds.csv"
+filecollege = "data/college_seeds.csv"
+
+# Initialisation de la date du jour (démarrant à 00:00:00)
+TODAY = DateTime.tomorrow.to_time
+
+# Creation des activité spécifiques à la journée demo day
+CSV.foreach(filetoday, headers: :first_row) do |row|
+  today_activity = Activity.new(
+    name: row['name'],
+    activity_type: row['activity_type'],
+    description: row['description'],
+    starting_date: TODAY + row['starting_time'],
+    ending_date: TODAY + row['starting_time'] + row['duration'],
     child_id: Child.last.id,
     educator_id: Educator.all.sample.id,
-    relative_id: Relative.all.sample.id,
-    activity_type: LIST_ACTIV_TYPES[index]
-)
-  file = URI.parse(Cloudinary::Utils.cloudinary_url(LIST_PICTURES[index])).open
-  activite.photo.attach(io: file, filename: "#{LIST_ACTIVITIES[index]}.jpeg", content_type:"image/jpeg")
-  activite.save
-  puts "#{activite.name} créé"
+    relative_id: Relative.all.sample.id
+  )
+  file = URI.parse(Cloudinary::Utils.cloudinary_url(row['picture'])).open
+  today_activity.photo.attach(io: file, filename: "#{today_activity.name}.jpeg", content_type:"image/jpeg")
+  today_activity.save
+  puts "#{today_activity.name} créé"
 end


### PR DESCRIPTION
Seeds created with CSV file for easier maintenance
- one seed for the demo day
- one seed for example of school day
- Real timeline is now applied (duration of lessons is 55minutes)

Free time is left between the cards in the agenda, proportionnaly to timelaps between activities
**Warning : we will have to consider a view for each day, otherwise user will need to scroll empty space to access to next day**
![image](https://github.com/user-attachments/assets/05d89702-8bb9-41fe-85eb-75dc76d62539)
![image](https://github.com/user-attachments/assets/52d39ba4-af78-4484-94fe-7790f1d0cdab)
