### PR TITLE
bug activity card image size fixed

### DIFF
--- a/app/views/activities/_activity_card_details.html.erb
+++ b/app/views/activities/_activity_card_details.html.erb
@@ -1,5 +1,5 @@
 <%# <div class="right-side"> %>
-  <div class="card-details">
+  <div class="card-details w-100">
       <div class="image-container">
       <%=cl_image_tag(activity.photo.key)%>
       <div class="overlay-image-educator">


### PR DESCRIPTION
<img width="341" alt="Capture d’écran 2025-03-19 à 10 12 08" src="https://github.com/user-attachments/assets/0535456a-f6ee-41a9-9e49-fe5afcd00054" />


ajout d'une class bootstrap dans le   <div class="card-details w-100"> 